### PR TITLE
Fix non-gerber pos files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ kicad-cli pcb export drill -o "$output" "$input"
 kicad-cli pcb export gerbers -o "$output" "$input"
 
 if [[ "$placement_format" == "ascii" || "$placement_format" == "csv" ]]; then
-    kicad-cli pcb export pos --format "$placement_format" -o "$output" "$input"
+    kicad-cli pcb export pos --format "$placement_format" -o "$output/$filename.pos" "$input"
 elif [[ "$placement_format" == "gerber" ]]; then
     kicad-cli pcb export pos --format gerber --side front -o "$output/$filename.front.pos" "$input"
     kicad-cli pcb export pos --format gerber --side back -o "$output/$filename.back.pos" "$input"


### PR DESCRIPTION
Fixes the issue raised with the implementation of the feature request in #1.

I incorrectly assumed that when given a directory, KiCad would, like with drill files, place in the directory a file with the name <pcb_name>.pos. Apparently the pos command works differently, and this fix reflects that.